### PR TITLE
Conform to Mustache spec

### DIFF
--- a/Sources/HummingbirdMustache/Parser.swift
+++ b/Sources/HummingbirdMustache/Parser.swift
@@ -284,7 +284,7 @@ extension HBParser {
             unsafeAdvance()
         }
         if startIndex == index {
-            return subParser(startIndex..<startIndex)
+            return subParser(startIndex ..< startIndex)
         }
         return subParser(startIndex ..< index)
     }
@@ -404,8 +404,9 @@ extension HBParser {
     func getPosition() -> Int {
         return index
     }
+
     mutating func setPosition(_ index: Int) throws {
-        guard range.contains(index)  else { throw Error.invalidPosition }
+        guard range.contains(index) else { throw Error.invalidPosition }
         guard validateUTF8Character(at: index).0 != nil else { throw Error.invalidPosition }
         _setPosition(index)
     }

--- a/Sources/HummingbirdMustache/Parser.swift
+++ b/Sources/HummingbirdMustache/Parser.swift
@@ -15,6 +15,7 @@ struct HBParser {
         case unexpected
         case emptyString
         case invalidUTF8
+        case invalidPosition
     }
 
     /// Create a Parser object
@@ -282,6 +283,9 @@ extension HBParser {
         {
             unsafeAdvance()
         }
+        if startIndex == index {
+            return subParser(startIndex..<startIndex)
+        }
         return subParser(startIndex ..< index)
     }
 
@@ -395,6 +399,15 @@ extension HBParser {
             index = skipUTF8Character(at: index)
             amount -= 1
         }
+    }
+
+    func getPosition() -> Int {
+        return index
+    }
+    mutating func setPosition(_ index: Int) throws {
+        guard range.contains(index)  else { throw Error.invalidPosition }
+        guard validateUTF8Character(at: index).0 != nil else { throw Error.invalidPosition }
+        _setPosition(index)
     }
 }
 

--- a/Sources/HummingbirdMustache/Sequence.swift
+++ b/Sources/HummingbirdMustache/Sequence.swift
@@ -2,37 +2,45 @@
 /// Protocol for objects that can be rendered as a sequence in Mustache
 public protocol HBMustacheSequence {
     /// Render section using template
-    func renderSection(with template: HBMustacheTemplate) -> String
+    func renderSection(with template: HBMustacheTemplate, stack: [Any]) -> String
     /// Render inverted section using template
-    func renderInvertedSection(with template: HBMustacheTemplate) -> String
+    func renderInvertedSection(with template: HBMustacheTemplate, stack: [Any]) -> String
 }
 
 public extension Sequence {
     /// Render section using template
-    func renderSection(with template: HBMustacheTemplate) -> String {
+    func renderSection(with template: HBMustacheTemplate, stack: [Any]) -> String {
         var string = ""
         var context = HBMustacheContext(first: true)
+
         var iterator = makeIterator()
         guard var currentObject = iterator.next() else { return "" }
 
         while let object = iterator.next() {
-            string += template.render(currentObject, context: context)
+            var stack = stack
+            stack.append(currentObject)
+            string += template.render(stack, context: context)
             currentObject = object
             context.first = false
             context.index += 1
         }
 
         context.last = true
-        string += template.render(currentObject, context: context)
+        var stack = stack
+        stack.append(currentObject)
+        string += template.render(stack, context: context)
 
         return string
     }
 
     /// Render inverted section using template
-    func renderInvertedSection(with template: HBMustacheTemplate) -> String {
+    func renderInvertedSection(with template: HBMustacheTemplate, stack: [Any]) -> String {
+        var stack = stack
+        stack.append(self)
+
         var iterator = makeIterator()
         if iterator.next() == nil {
-            return template.render(self)
+            return template.render(stack)
         }
         return ""
     }

--- a/Sources/HummingbirdMustache/Template+Parser.swift
+++ b/Sources/HummingbirdMustache/Template+Parser.swift
@@ -59,6 +59,11 @@ extension HBMustacheTemplate {
                 guard try parser.read("}") else { throw Error.unfinishedName }
                 tokens.append(.unescapedVariable(name: name, method: method))
 
+            case "&":
+                parser.unsafeAdvance()
+                let (name, method) = try parseName(&parser)
+                tokens.append(.unescapedVariable(name: name, method: method))
+
             case "!":
                 parser.unsafeAdvance()
                 _ = try parseComment(&parser)

--- a/Sources/HummingbirdMustache/Template+Parser.swift
+++ b/Sources/HummingbirdMustache/Template+Parser.swift
@@ -62,11 +62,17 @@ extension HBMustacheTemplate {
             case "!":
                 parser.unsafeAdvance()
                 _ = try parseComment(&parser)
+                if parser.current() == "\n" {
+                    parser.unsafeAdvance()
+                }
 
             case ">":
                 parser.unsafeAdvance()
                 let (name, _) = try parseName(&parser)
                 tokens.append(.partial(name))
+                if parser.current() == "\n" {
+                    parser.unsafeAdvance()
+                }
 
             default:
                 let (name, method) = try parseName(&parser)

--- a/Sources/HummingbirdMustache/Template+Parser.swift
+++ b/Sources/HummingbirdMustache/Template+Parser.swift
@@ -61,7 +61,7 @@ extension HBMustacheTemplate {
                 // section
                 parser.unsafeAdvance()
                 let (name, method) = try parseName(&parser)
-                if newLine && hasLineFinished(&parser) {
+                if newLine, hasLineFinished(&parser) {
                     setNewLine = true
                     if parser.current() == "\n" {
                         parser.unsafeAdvance()
@@ -77,7 +77,7 @@ extension HBMustacheTemplate {
                 // inverted section
                 parser.unsafeAdvance()
                 let (name, method) = try parseName(&parser)
-                if newLine && hasLineFinished(&parser) {
+                if newLine, hasLineFinished(&parser) {
                     setNewLine = true
                     if parser.current() == "\n" {
                         parser.unsafeAdvance()
@@ -96,7 +96,7 @@ extension HBMustacheTemplate {
                 guard name == sectionName else {
                     throw Error.sectionCloseNameIncorrect
                 }
-                if newLine && hasLineFinished(&parser) {
+                if newLine, hasLineFinished(&parser) {
                     setNewLine = true
                     if parser.current() == "\n" {
                         parser.unsafeAdvance()
@@ -111,7 +111,7 @@ extension HBMustacheTemplate {
                 // comment
                 parser.unsafeAdvance()
                 _ = try parseComment(&parser)
-                if newLine && hasLineFinished(&parser) {
+                if newLine, hasLineFinished(&parser) {
                     setNewLine = true
                     if !parser.reachedEnd() {
                         parser.unsafeAdvance()
@@ -143,16 +143,16 @@ extension HBMustacheTemplate {
                 // partial
                 parser.unsafeAdvance()
                 let (name, _) = try parseName(&parser)
-                /*if newLine && hasLineFinished(&parser) {
-                    setNewLine = true
-                    if parser.current() == "\n" {
-                        parser.unsafeAdvance()
-                    }
-                }*/
+                /* if newLine && hasLineFinished(&parser) {
+                     setNewLine = true
+                     if parser.current() == "\n" {
+                         parser.unsafeAdvance()
+                     }
+                 } */
                 if whiteSpaceBefore.count > 0 {
                     tokens.append(.text(whiteSpaceBefore))
                 }
-                if newLine && hasLineFinished(&parser) {
+                if newLine, hasLineFinished(&parser) {
                     setNewLine = true
                     if parser.current() == "\n" {
                         parser.unsafeAdvance()

--- a/Sources/HummingbirdMustache/Template+Parser.swift
+++ b/Sources/HummingbirdMustache/Template+Parser.swift
@@ -143,12 +143,6 @@ extension HBMustacheTemplate {
                 // partial
                 parser.unsafeAdvance()
                 let (name, _) = try parseName(&parser)
-                /* if newLine && hasLineFinished(&parser) {
-                     setNewLine = true
-                     if parser.current() == "\n" {
-                         parser.unsafeAdvance()
-                     }
-                 } */
                 if whiteSpaceBefore.count > 0 {
                     tokens.append(.text(whiteSpaceBefore))
                 }

--- a/Sources/HummingbirdMustache/Template+Render.swift
+++ b/Sources/HummingbirdMustache/Template+Render.swift
@@ -5,9 +5,12 @@ extension HBMustacheTemplate {
     ///   - object: Object
     ///   - context: Context that render is occurring in. Contains information about position in sequence
     /// - Returns: Rendered text
-    func render(_ object: Any, context: HBMustacheContext? = nil) -> String {
+    func render(_ object: Any, context: HBMustacheContext? = nil, indentation: String? = nil) -> String {
         var string = ""
         for token in tokens {
+            if let indentation = indentation, string.last == "\n" {
+                string += indentation
+            }
             switch token {
             case let .text(text):
                 string += text
@@ -31,9 +34,9 @@ extension HBMustacheTemplate {
                 let child = getChild(named: variable, from: object, method: method, context: context)
                 string += renderInvertedSection(child, parent: object, with: template)
 
-            case let .partial(name):
-                if let text = library?.render(object, withTemplate: name) {
-                    string += text
+            case let .partial(name, indentation):
+                if let template = library?.getTemplate(named: name) {
+                    string += template.render(object, indentation: indentation)
                 }
             }
         }

--- a/Sources/HummingbirdMustache/Template.swift
+++ b/Sources/HummingbirdMustache/Template.swift
@@ -11,7 +11,7 @@ public final class HBMustacheTemplate {
     /// - Parameter object: Object to render
     /// - Returns: Rendered text
     public func render(_ object: Any) -> String {
-        render(object, context: nil)
+        render([object], context: nil)
     }
 
     internal init(_ tokens: [Token]) {

--- a/Sources/HummingbirdMustache/Template.swift
+++ b/Sources/HummingbirdMustache/Template.swift
@@ -36,7 +36,7 @@ public final class HBMustacheTemplate {
         case unescapedVariable(name: String, method: String? = nil)
         case section(name: String, method: String? = nil, template: HBMustacheTemplate)
         case invertedSection(name: String, method: String? = nil, template: HBMustacheTemplate)
-        case partial(String)
+        case partial(String, indentation: String?)
     }
 
     let tokens: [Token]

--- a/Tests/HummingbirdMustacheTests/MethodTests.swift
+++ b/Tests/HummingbirdMustacheTests/MethodTests.swift
@@ -18,11 +18,28 @@ final class MethodTests: XCTestCase {
         XCTAssertEqual(template.render(object), "TEST")
     }
 
+    func testNewline() throws {
+        let template = try HBMustacheTemplate(string: """
+        {{#repo}}
+        <b>{{name}}</b>
+        {{/repo}}
+
+        """)
+        let object: [String: Any] = ["repo": [["name": "resque"], ["name": "hub"], ["name": "rip"]]]
+        XCTAssertEqual(template.render(object), """
+        <b>resque</b>
+        <b>hub</b>
+        <b>rip</b>
+
+        """)
+    }
+
     func testFirstLast() throws {
         let template = try HBMustacheTemplate(string: """
         {{#repo}}
         <b>{{#first()}}first: {{/}}{{#last()}}last: {{/}}{{ name }}</b>
         {{/repo}}
+
         """)
         let object: [String: Any] = ["repo": [["name": "resque"], ["name": "hub"], ["name": "rip"]]]
         XCTAssertEqual(template.render(object), """
@@ -38,6 +55,7 @@ final class MethodTests: XCTestCase {
         {{#repo}}
         <b>{{#index()}}{{plusone(.)}}{{/}}) {{ name }}</b>
         {{/repo}}
+
         """)
         let object: [String: Any] = ["repo": [["name": "resque"], ["name": "hub"], ["name": "rip"]]]
         XCTAssertEqual(template.render(object), """
@@ -53,6 +71,7 @@ final class MethodTests: XCTestCase {
         {{#repo}}
         <b>{{index()}}) {{#even()}}even {{/}}{{#odd()}}odd {{/}}{{ name }}</b>
         {{/repo}}
+
         """)
         let object: [String: Any] = ["repo": [["name": "resque"], ["name": "hub"], ["name": "rip"]]]
         XCTAssertEqual(template.render(object), """
@@ -68,6 +87,7 @@ final class MethodTests: XCTestCase {
         {{#reversed(repo)}}
           <b>{{ name }}</b>
         {{/repo}}
+
         """)
         let object: [String: Any] = ["repo": [["name": "resque"], ["name": "hub"], ["name": "rip"]]]
         XCTAssertEqual(template.render(object), """

--- a/Tests/HummingbirdMustacheTests/PartialTests.swift
+++ b/Tests/HummingbirdMustacheTests/PartialTests.swift
@@ -13,6 +13,7 @@ final class PartialTests: XCTestCase {
         """)
         let template2 = try HBMustacheTemplate(string: """
         <strong>{{.}}</strong>
+
         """)
         library.register(template, named: "base")
         library.register(template2, named: "user")

--- a/Tests/HummingbirdMustacheTests/SpecTests.swift
+++ b/Tests/HummingbirdMustacheTests/SpecTests.swift
@@ -644,3 +644,31 @@ final class SpecPartialsTests: XCTestCase {
         try testPartial(object, template, ["partial": partial], expected)
     }
 }
+
+// MARK: Sections
+
+final class SpecSectionTests: XCTestCase {
+    func testTrue() throws {
+        let object = ["boolean": true]
+        let template = #""{{#boolean}}This should be rendered.{{/boolean}}""#
+        let expected = #""This should be rendered.""#
+        try test(object, template, expected)
+
+    }
+
+    func testFalse() throws {
+        let object = ["boolean": false]
+        let template = #""{{#boolean}}This should not be rendered.{{/boolean}}""#
+        let expected = "\"\""
+        try test(object, template, expected)
+
+    }
+
+    func testContext() throws {
+        let object = ["context": ["name": "Joe"]]
+        let template = #""{{#context}}Hi {{name}}.{{/context}}""#
+        let expected = #""Hi Joe.""#
+        try test(object, template, expected)
+
+    }
+}

--- a/Tests/HummingbirdMustacheTests/SpecTests.swift
+++ b/Tests/HummingbirdMustacheTests/SpecTests.swift
@@ -390,6 +390,7 @@ final class SpecInvertedTests: XCTestCase {
         * first
         * second
         * third
+
         """
         try test(object, template, expected)
     }

--- a/Tests/HummingbirdMustacheTests/SpecTests.swift
+++ b/Tests/HummingbirdMustacheTests/SpecTests.swift
@@ -10,10 +10,9 @@ func test(_ object: Any, _ template: String, _ expected: String) throws {
     XCTAssertEqual(result, expected)
 }
 
-//MARK: Comments
+// MARK: Comments
 
 final class SpecCommentsTests: XCTestCase {
-
     func testInline() throws {
         let object = {}
         let template = "12345{{! Comment Block! }}67890"
@@ -98,14 +97,14 @@ final class SpecCommentsTests: XCTestCase {
         try test(object, template, expected)
     }
 
-    func testIndentedInline()  throws {
+    func testIndentedInline() throws {
         let object = {}
         let template = "  12 {{! 34 }}\n"
         let expected = "  12 \n"
         try test(object, template, expected)
     }
 
-    func testSurroundingWhitespace()  throws {
+    func testSurroundingWhitespace() throws {
         let object = {}
         let template = "12345 {{! Comment Block! }} 67890"
         let expected = "12345  67890"
@@ -113,7 +112,7 @@ final class SpecCommentsTests: XCTestCase {
     }
 }
 
-//MARK: Interpolation
+// MARK: Interpolation
 
 final class SpecInterpolationTests: XCTestCase {
     func testNoInterpolation() throws {
@@ -121,71 +120,66 @@ final class SpecInterpolationTests: XCTestCase {
         let template = "Hello from {Mustache}!"
         let expected = "Hello from {Mustache}!"
         try test(object, template, expected)
-
     }
 
     func testBasicInterpolation() throws {
-        let object = [ "subject": "world" ]
+        let object = ["subject": "world"]
         let template = "Hello, {{subject}}!"
         let expected = "Hello, world!"
         try test(object, template, expected)
-
     }
 
     func testHTMLEscaping() throws {
-        let object = [ "forbidden": #"& " < >"# ]
+        let object = ["forbidden": #"& " < >"#]
         let template = "These characters should be HTML escaped: {{forbidden}}"
         let expected = #"These characters should be HTML escaped: &amp; &quot; &lt; &gt;"#
         try test(object, template, expected)
-
     }
 
     func testTripleMustache() throws {
-        let object = [ "forbidden": #"& " < >"# ]
+        let object = ["forbidden": #"& " < >"#]
         let template = "These characters should not be HTML escaped: {{{forbidden}}}"
         let expected = #"These characters should not be HTML escaped: & " < >"#
         try test(object, template, expected)
-
     }
 
     func testAmpersand() throws {
-        let object = [ "forbidden": #"& " < >"# ]
+        let object = ["forbidden": #"& " < >"#]
         let template = "These characters should not be HTML escaped: {{&forbidden}}"
         let expected = #"These characters should not be HTML escaped: & " < >"#
         try test(object, template, expected)
-
     }
 
     func testBasicInteger() throws {
-        let object = [ "mph": 85 ]
+        let object = ["mph": 85]
         let template = #""{{mph}} miles an hour!""#
         let expected = #""85 miles an hour!""#
         try test(object, template, expected)
     }
 
     func testTripleMustacheInteger() throws {
-        let object = [ "mph": 85 ]
+        let object = ["mph": 85]
         let template = #""{{{mph}}} miles an hour!""#
         let expected = #""85 miles an hour!""#
         try test(object, template, expected)
     }
 
     func testBasicDecimal() throws {
-        let object = [ "power": 1.210 ]
+        let object = ["power": 1.210]
         let template = #""{{power}} jiggawatts!""#
         let expected = #""1.21 jiggawatts!""#
         try test(object, template, expected)
     }
 
     func testTripleMustacheDecimal() throws {
-        let object = [ "power": 1.210 ]
+        let object = ["power": 1.210]
         let template = #""{{{power}}} jiggawatts!""#
         let expected = #""1.21 jiggawatts!""#
         try test(object, template, expected)
     }
 
     func testAmpersandDecimal() throws {
-        let object = [ "power": 1.210 ]
+        let object = ["power": 1.210]
         let template = #""{{&power}} jiggawatts!""#
         let expected = #""1.21 jiggawatts!""#
         try test(object, template, expected)
@@ -250,7 +244,7 @@ final class SpecInterpolationTests: XCTestCase {
     func testInitialResolutionDottedName() throws {
         let object = [
             "a": ["b": ["c": ["d": ["e": ["name": "Phil"]]]]],
-            "b": ["c": ["d": ["e": ["name": "Wrong"]]]]
+            "b": ["c": ["d": ["e": ["name": "Wrong"]]]],
         ]
         let template = #""{{#a}}{{b.c.d.e.name}}{{/a}}" == "Phil""#
         let expected = #""Phil" == "Phil""#
@@ -260,7 +254,7 @@ final class SpecInterpolationTests: XCTestCase {
     func testContextPrecedenceDottedName() throws {
         let object = [
             "a": ["b": []],
-            "b": ["c": "Error"]
+            "b": ["c": "Error"],
         ]
         let template = #"{{#a}}{{b.c}}{{/a}}"#
         let expected = ""
@@ -314,7 +308,6 @@ final class SpecInterpolationTests: XCTestCase {
         let template = "|{{ string }}|"
         let expected = "|---|"
         try test(object, template, expected)
-
     }
 
     func testTripleMustacheWithPadding() throws {
@@ -322,7 +315,6 @@ final class SpecInterpolationTests: XCTestCase {
         let template = "|{{{ string }}}|"
         let expected = "|---|"
         try test(object, template, expected)
-
     }
 
     func testAmpersandWithPadding() throws {
@@ -341,7 +333,6 @@ final class SpecInvertedTests: XCTestCase {
         let template = #""{{^boolean}}This should be rendered.{{/boolean}}""#
         let expected = #""This should be rendered.""#
         try test(object, template, expected)
-
     }
 
     func testTrue() throws {
@@ -349,7 +340,6 @@ final class SpecInvertedTests: XCTestCase {
         let template = #""{{^boolean}}This should not be rendered.{{/boolean}}""#
         let expected = "\"\""
         try test(object, template, expected)
-
     }
 
     func testContext() throws {
@@ -357,7 +347,6 @@ final class SpecInvertedTests: XCTestCase {
         let template = #""{{^context}}Hi {{name}}.{{/context}}""#
         let expected = "\"\""
         try test(object, template, expected)
-
     }
 
     func testList() throws {
@@ -365,7 +354,6 @@ final class SpecInvertedTests: XCTestCase {
         let template = #""{{^list}}{{n}}{{/list}}""#
         let expected = "\"\""
         try test(object, template, expected)
-
     }
 
     func testEmptyList() throws {
@@ -442,7 +430,6 @@ final class SpecInvertedTests: XCTestCase {
         let template = " | {{^boolean}}\t|\t{{/boolean}} | \n"
         let expected = " | \t|\t | \n"
         try test(object, template, expected)
-
     }
 
     func testInternalWhitespace() throws {
@@ -450,7 +437,6 @@ final class SpecInvertedTests: XCTestCase {
         let template = " | {{^boolean}} {{! Important Whitespace }}\n {{/boolean}} | \n"
         let expected = " |  \n  | \n"
         try test(object, template, expected)
-
     }
 
     func testIndentedInline() throws {
@@ -458,7 +444,6 @@ final class SpecInvertedTests: XCTestCase {
         let template = " {{^boolean}}NO{{/boolean}}\n {{^boolean}}WAY{{/boolean}}\n"
         let expected = " NO\n WAY\n"
         try test(object, template, expected)
-
     }
 
     func testStandaloneLines() throws {
@@ -476,7 +461,6 @@ final class SpecInvertedTests: XCTestCase {
         | A Line
         """
         try test(object, template, expected)
-
     }
 
     func testStandaloneIndentedLines() throws {
@@ -501,7 +485,6 @@ final class SpecInvertedTests: XCTestCase {
         let template = "|\r\n{{^boolean}}\r\n{{/boolean}}\r\n|"
         let expected = "|\r\n|"
         try test(object, template, expected)
-
     }
 
     func testStandaloneWithoutPreviousLine() throws {
@@ -637,7 +620,7 @@ final class SpecPartialsTests: XCTestCase {
     }
 
     func testPaddingWhitespace() throws {
-        let object = ["boolean": true ]
+        let object = ["boolean": true]
         let template = "|{{> partial }}|"
         let partial = "[]"
         let expected = "|[]|"
@@ -653,7 +636,6 @@ final class SpecSectionTests: XCTestCase {
         let template = #""{{#boolean}}This should be rendered.{{/boolean}}""#
         let expected = #""This should be rendered.""#
         try test(object, template, expected)
-
     }
 
     func testFalse() throws {
@@ -661,7 +643,6 @@ final class SpecSectionTests: XCTestCase {
         let template = #""{{#boolean}}This should not be rendered.{{/boolean}}""#
         let expected = "\"\""
         try test(object, template, expected)
-
     }
 
     func testContext() throws {
@@ -792,33 +773,32 @@ final class SpecSectionTests: XCTestCase {
     }
 
     func testImplicitIteratorString() throws {
-        let object = ["list": [ "a", "b", "c", "d", "e" ]]
+        let object = ["list": ["a", "b", "c", "d", "e"]]
         let template = #""{{#list}}({{.}}){{/list}}""#
         let expected = #""(a)(b)(c)(d)(e)""#
         try test(object, template, expected)
     }
 
     func testImplicitIteratorInteger() throws {
-        let object = ["list": [ 1, 2, 3, 4, 5 ]]
+        let object = ["list": [1, 2, 3, 4, 5]]
         let template = #""{{#list}}({{.}}){{/list}}""#
         let expected = #""(1)(2)(3)(4)(5)""#
         try test(object, template, expected)
     }
 
     func testImplicitIteratorDecimal() throws {
-        let object = ["list": [ 1.1, 2.2, 3.3, 4.4, 5.5 ]]
+        let object = ["list": [1.1, 2.2, 3.3, 4.4, 5.5]]
         let template = #""{{#list}}({{.}}){{/list}}""#
         let expected = #""(1.1)(2.2)(3.3)(4.4)(5.5)""#
         try test(object, template, expected)
     }
 
     func testImplicitIteratorArray() throws {
-        let object: [String: Any] = ["list": [[ 1, 2, 3], [ "a", "b", "c"]]]
+        let object: [String: Any] = ["list": [[1, 2, 3], ["a", "b", "c"]]]
         let template = #""{{#list}}({{#.}}{{.}}{{/.}}){{/list}}""#
         let expected = #""(123)(abc)""#
         try test(object, template, expected)
     }
-
 
     func testDottedNameTrue() throws {
         let object = ["a": ["b": ["c": true]]]

--- a/Tests/HummingbirdMustacheTests/SpecTests.swift
+++ b/Tests/HummingbirdMustacheTests/SpecTests.swift
@@ -393,4 +393,134 @@ final class SpecInvertedTests: XCTestCase {
         """
         try test(object, template, expected)
     }
+
+    func testNestedFalse() throws {
+        let object = ["bool": false]
+        let template = #"| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |"#
+        let expected = #"| A B C D E |"#
+        try test(object, template, expected)
+    }
+
+    func testNestedTrue() throws {
+        let object = ["bool": true]
+        let template = #"| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |"#
+        let expected = #"| A  E |"#
+        try test(object, template, expected)
+    }
+
+    func testContextMiss() throws {
+        let object = {}
+        let template = #"[{{^missing}}Cannot find key 'missing'!{{/missing}}]"#
+        let expected = #"[Cannot find key 'missing'!]"#
+        try test(object, template, expected)
+    }
+
+    func testDottedNamesTrue() throws {
+        let object = ["a": ["b": ["c": true]]]
+        let template = #""{{^a.b.c}}Not Here{{/a.b.c}}" == """#
+        let expected = "\"\" == \"\""
+        try test(object, template, expected)
+    }
+
+    func testDottedNamesFalse() throws {
+        let object = ["a": ["b": ["c": false]]]
+        let template = #""{{^a.b.c}}Not Here{{/a.b.c}}" == "Not Here""#
+        let expected = #""Not Here" == "Not Here""#
+        try test(object, template, expected)
+    }
+
+    func testDottedNamesBrokenChain() throws {
+        let object = ["a": {}]
+        let template = #""{{^a.b.c}}Not Here{{/a.b.c}}" == "Not Here""#
+        let expected = #""Not Here" == "Not Here""#
+        try test(object, template, expected)
+    }
+
+    func testSurroundingWhitespace() throws {
+        let object = ["boolean": false]
+        let template = " | {{^boolean}}\t|\t{{/boolean}} | \n"
+        let expected = " | \t|\t | \n"
+        try test(object, template, expected)
+
+    }
+
+    func testInternalWhitespace() throws {
+        let object = ["boolean": false]
+        let template = " | {{^boolean}} {{! Important Whitespace }}\n {{/boolean}} | \n"
+        let expected = " |  \n  | \n"
+        try test(object, template, expected)
+
+    }
+
+    func testIndentedInline() throws {
+        let object = ["boolean": false]
+        let template = " {{^boolean}}NO{{/boolean}}\n {{^boolean}}WAY{{/boolean}}\n"
+        let expected = " NO\n WAY\n"
+        try test(object, template, expected)
+
+    }
+
+    func testStandaloneLines() throws {
+        let object = ["boolean": false]
+        let template = """
+        | This Is
+        {{^boolean}}
+        |
+        {{/boolean}}
+        | A Line
+        """
+        let expected = """
+        | This Is
+        |
+        | A Line
+        """
+        try test(object, template, expected)
+
+    }
+
+    func testStandaloneIndentedLines() throws {
+        let object = ["boolean": false]
+        let template = """
+        | This Is
+          {{^boolean}}
+        |
+          {{/boolean}}
+        | A Line
+        """
+        let expected = """
+        | This Is
+        |
+        | A Line
+        """
+        try test(object, template, expected)
+    }
+
+    func testStandaloneLineEndings() throws {
+        let object = ["boolean": false]
+        let template = "|\r\n{{^boolean}}\r\n{{/boolean}}\r\n|"
+        let expected = "|\r\n|"
+        try test(object, template, expected)
+
+    }
+
+    func testStandaloneWithoutPreviousLine() throws {
+        let object = ["boolean": false]
+        let template = "  {{^boolean}}\n^{{/boolean}}\n/"
+        let expected = "^\n/"
+        try test(object, template, expected)
+    }
+
+    func testStandaloneWithoutNewLine() throws {
+        let object = ["boolean": false]
+        let template = "^{{^boolean}}\n/\n  {{/boolean}}"
+        let expected = "^\n/\n"
+        try test(object, template, expected)
+    }
+
+    func testPadding() throws {
+        let object = ["boolean": false]
+        let template = "|{{^ boolean }}={{/ boolean }}|"
+        let expected = "|=|"
+        try test(object, template, expected)
+    }
 }

--- a/Tests/HummingbirdMustacheTests/SpecTests.swift
+++ b/Tests/HummingbirdMustacheTests/SpecTests.swift
@@ -661,8 +661,8 @@ final class SpecSectionTests: XCTestCase {
 
     func testVariables() throws {
         let object: [String: Any] = ["foo": "bar"]
-        let template = #""{{#foo}} {{.}} is {{foo}} {{/foo}}""#
-        let expected = #"" bar is bar ""#
+        let template = #""{{#foo}}{{.}} is {{foo}}{{/foo}}""#
+        let expected = #""bar is bar""#
         try test(object, template, expected)
     }
 

--- a/Tests/HummingbirdMustacheTests/SpecTests.swift
+++ b/Tests/HummingbirdMustacheTests/SpecTests.swift
@@ -1,0 +1,114 @@
+import HummingbirdMustache
+import XCTest
+
+/// Mustache spec tests. These are the formal standard for Mustache. More details
+/// can be found at https://github.com/mustache/spec
+
+func test(_ object: Any, _ template: String, _ expected: String) throws {
+    let template = try HBMustacheTemplate(string: template)
+    let result = template.render(object)
+    XCTAssertEqual(result, expected)
+}
+
+//MARK: Comments
+
+final class SpecCommentsTests: XCTestCase {
+
+    func testInline() throws {
+        let object = {}
+        let template = "12345{{! Comment Block! }}67890"
+        let expected = "1234567890"
+        try test(object, template, expected)
+    }
+
+    func testMultiline() throws {
+        let object = {}
+        let template = """
+        12345{{!
+                This is a
+                multi-line comment...
+              }}67890
+        """
+        let expected = "1234567890"
+        try test(object, template, expected)
+    }
+
+    func testStandalone() throws {
+        let object = {}
+        let template = """
+        Begin.
+        {{! Comment Block! }}
+        End.
+        """
+        let expected = """
+        Begin.
+        End.
+        """
+        try test(object, template, expected)
+    }
+
+    func testIndentedStandalone() throws {
+        let object = {}
+        let template = """
+        Begin.
+          {{! Comment Block! }}
+        End.
+        """
+        let expected = """
+        Begin.
+        End.
+        """
+        try test(object, template, expected)
+    }
+
+    func testStandaloneLineEndings() throws {
+        let object = {}
+        let template = "\r\n{{! Standalone Comment }}\r\n"
+        let expected = "\r\n"
+        try test(object, template, expected)
+    }
+
+    func testStandaloneWithoutPreviousLine() throws {
+        let object = {}
+        let template = "  {{! I'm Still Standalone }}\n!"
+        let expected = "!"
+        try test(object, template, expected)
+    }
+
+    func testStandaloneWithoutNewLine() throws {
+        let object = {}
+        let template = "!\n  {{! I'm Still Standalone }}"
+        let expected = "!\n"
+        try test(object, template, expected)
+    }
+
+    func testStandaloneMultiLine() throws {
+        let object = {}
+        let template = """
+        Begin.
+          {{!
+            Something's going on here...
+          }}
+        End.
+        """
+        let expected = """
+        Begin.
+        End.
+        """
+        try test(object, template, expected)
+    }
+
+    func testIndentedInline()  throws {
+        let object = {}
+        let template = "  12 {{! 34 }}\n"
+        let expected = "  12 \n"
+        try test(object, template, expected)
+    }
+
+    func testSurroundingWhitespace()  throws {
+        let object = {}
+        let template = "12345 {{! Comment Block! }} 67890"
+        let expected = "12345  67890"
+        try test(object, template, expected)
+    }
+}

--- a/Tests/HummingbirdMustacheTests/TemplateParserTests.swift
+++ b/Tests/HummingbirdMustacheTests/TemplateParserTests.swift
@@ -83,8 +83,8 @@ extension HBMustacheTemplate.Token: Equatable {
             return lhs1 == rhs1 && lhs2 == rhs2 && lhs3 == rhs3
         case let (.invertedSection(lhs1, lhs2, lhs3), .invertedSection(rhs1, rhs2, rhs3)):
             return lhs1 == rhs1 && lhs2 == rhs2 && lhs3 == rhs3
-        case let (.partial(name1), .partial(name2)):
-            return name1 == name2
+        case let (.partial(name1, indent1), .partial(name2, indent2)):
+            return name1 == name2 && indent1 == indent2
         default:
             return false
         }


### PR DESCRIPTION
You can find the spec [here](https://github.com/mustache/spec).
Added all the tests except the delimiter tests as we don't support delimiter setting yet
Parser reads line by line now to helps support standalone elements
Add support for unescaped `{{& }}`
Add context stack support