### PR TITLE
2.x.x Template struct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,10 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'swift:5.6'
           - 'swift:5.7'
           - 'swift:5.8'
+          - 'swift:5.9'
+          - 'swiftlang/swift:nightly-5.10-jammy'
     
     container:
       image: ${{ matrix.image }}

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,11 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "hummingbird-mustache",
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
     products: [
         .library(name: "HummingbirdMustache", targets: ["HummingbirdMustache"]),
     ],

--- a/Sources/HummingbirdMustache/ContentType.swift
+++ b/Sources/HummingbirdMustache/ContentType.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Protocol for content types
-public protocol HBMustacheContentType {
+public protocol HBMustacheContentType: Sendable {
     /// escape text for this content type eg for HTML replace "<" with "&lt;"
     func escapeText(_ text: String) -> String
 }

--- a/Sources/HummingbirdMustache/Context.swift
+++ b/Sources/HummingbirdMustache/Context.swift
@@ -19,14 +19,16 @@ struct HBMustacheContext {
     let indentation: String?
     let inherited: [String: HBMustacheTemplate]?
     let contentType: HBMustacheContentType
+    let library: HBMustacheLibrary?
 
     /// initialize context with a single objectt
-    init(_ object: Any) {
+    init(_ object: Any, library: HBMustacheLibrary? = nil) {
         self.stack = [object]
         self.sequenceContext = nil
         self.indentation = nil
         self.inherited = nil
         self.contentType = HBHTMLContentType()
+        self.library = library
     }
 
     private init(
@@ -34,13 +36,15 @@ struct HBMustacheContext {
         sequenceContext: HBMustacheSequenceContext?,
         indentation: String?,
         inherited: [String: HBMustacheTemplate]?,
-        contentType: HBMustacheContentType
+        contentType: HBMustacheContentType,
+        library: HBMustacheLibrary? = nil
     ) {
         self.stack = stack
         self.sequenceContext = sequenceContext
         self.indentation = indentation
         self.inherited = inherited
         self.contentType = contentType
+        self.library = library
     }
 
     /// return context with object add to stack
@@ -52,7 +56,8 @@ struct HBMustacheContext {
             sequenceContext: nil,
             indentation: self.indentation,
             inherited: self.inherited,
-            contentType: self.contentType
+            contentType: self.contentType,
+            library: self.library
         )
     }
 
@@ -79,7 +84,8 @@ struct HBMustacheContext {
             sequenceContext: nil,
             indentation: indentation,
             inherited: inherits,
-            contentType: HBHTMLContentType()
+            contentType: HBHTMLContentType(),
+            library: self.library
         )
     }
 
@@ -92,7 +98,8 @@ struct HBMustacheContext {
             sequenceContext: sequenceContext,
             indentation: self.indentation,
             inherited: self.inherited,
-            contentType: self.contentType
+            contentType: self.contentType,
+            library: self.library
         )
     }
 
@@ -103,7 +110,8 @@ struct HBMustacheContext {
             sequenceContext: self.sequenceContext,
             indentation: self.indentation,
             inherited: self.inherited,
-            contentType: contentType
+            contentType: contentType,
+            library: self.library
         )
     }
 }

--- a/Sources/HummingbirdMustache/Library+FileSystem.swift
+++ b/Sources/HummingbirdMustache/Library+FileSystem.swift
@@ -16,14 +16,15 @@ import Foundation
 
 extension HBMustacheLibrary {
     /// Load templates from a folder
-    func loadTemplates(from directory: String, withExtension extension: String = "mustache") throws {
+    static func loadTemplates(from directory: String, withExtension extension: String = "mustache") throws -> [String: HBMustacheTemplate] {
         var directory = directory
         if !directory.hasSuffix("/") {
             directory += "/"
         }
         let extWithDot = ".\(`extension`)"
         let fs = FileManager()
-        guard let enumerator = fs.enumerator(atPath: directory) else { return }
+        guard let enumerator = fs.enumerator(atPath: directory) else { return [:] }
+        var templates: [String: HBMustacheTemplate] = [:]
         for case let path as String in enumerator {
             guard path.hasSuffix(extWithDot) else { continue }
             guard let data = fs.contents(atPath: directory + path) else { continue }
@@ -36,8 +37,8 @@ extension HBMustacheLibrary {
             }
             // drop ".mustache" from path to get name
             let name = String(path.dropLast(extWithDot.count))
-            register(template, named: name)
+            templates[name] = template
         }
-        self.updatePartials()
+        return templates
     }
 }

--- a/Sources/HummingbirdMustache/Library+FileSystem.swift
+++ b/Sources/HummingbirdMustache/Library+FileSystem.swift
@@ -16,7 +16,7 @@ import Foundation
 
 extension HBMustacheLibrary {
     /// Load templates from a folder
-    static func loadTemplates(from directory: String, withExtension extension: String = "mustache") throws -> [String: HBMustacheTemplate] {
+    static func loadTemplates(from directory: String, withExtension extension: String = "mustache") async throws -> [String: HBMustacheTemplate] {
         var directory = directory
         if !directory.hasSuffix("/") {
             directory += "/"

--- a/Sources/HummingbirdMustache/Library+FileSystem.swift
+++ b/Sources/HummingbirdMustache/Library+FileSystem.swift
@@ -28,7 +28,7 @@ extension HBMustacheLibrary {
             guard path.hasSuffix(extWithDot) else { continue }
             guard let data = fs.contents(atPath: directory + path) else { continue }
             let string = String(decoding: data, as: Unicode.UTF8.self)
-            let template: HBMustacheTemplate
+            var template: HBMustacheTemplate
             do {
                 template = try HBMustacheTemplate(string: string)
             } catch let error as HBMustacheTemplate.ParserError {
@@ -38,5 +38,6 @@ extension HBMustacheLibrary {
             let name = String(path.dropLast(extWithDot.count))
             register(template, named: name)
         }
+        self.updatePartials()
     }
 }

--- a/Sources/HummingbirdMustache/Library.swift
+++ b/Sources/HummingbirdMustache/Library.swift
@@ -30,33 +30,25 @@ public final class HBMustacheLibrary: Sendable {
     /// the folder is recursive and templates in subfolders will be registered with the name `subfolder/template`.
     /// - Parameter directory: Directory to look for mustache templates
     /// - Parameter extension: Extension of files to look for
-    public init(directory: String, withExtension extension: String = "mustache") throws {
-        self.templates = [:]
-        try loadTemplates(from: directory, withExtension: `extension`)
-    }
-
-    /// Register template under name
-    /// - Parameters:
-    ///   - template: Template
-    ///   - name: Name of template
-    public func register(_ template: HBMustacheTemplate, named name: String) {
-        self.templates[name] = template
-    }
-
-    /// Register template under name
-    /// - Parameters:
-    ///   - mustache: Mustache text
-    ///   - name: Name of template
-    public func register(_ mustache: String, named name: String) throws {
-        let template = try HBMustacheTemplate(string: mustache)
-        self.templates[name] = template
-    }
-
-    /// Update partials in templates to reference other templates in the library
-    public func updatePartials() {
-        self.templates = self.templates.mapValues { template in
+    public init(templates: [String: HBMustacheTemplate]) {
+        self.templates = templates.mapValues { template in
             var template = template
-            template.setLibrary(self)
+            template.setLibrary(templates)
+            return template
+        }
+    }
+
+    /// Initialize library with contents of folder.
+    ///
+    /// Each template is registered with the name of the file minus its extension. The search through
+    /// the folder is recursive and templates in subfolders will be registered with the name `subfolder/template`.
+    /// - Parameter directory: Directory to look for mustache templates
+    /// - Parameter extension: Extension of files to look for
+    public init(directory: String, withExtension extension: String = "mustache") throws {
+        let templates = try Self.loadTemplates(from: directory, withExtension: `extension`)
+        self.templates = templates.mapValues { template in
+            var template = template
+            template.setLibrary(templates)
             return template
         }
     }
@@ -88,7 +80,5 @@ public final class HBMustacheLibrary: Sendable {
         public let error: Error
     }
 
-    private var templates: [String: HBMustacheTemplate]
+    private let templates: [String: HBMustacheTemplate]
 }
-
-public final class HBMutable

--- a/Sources/HummingbirdMustache/Library.swift
+++ b/Sources/HummingbirdMustache/Library.swift
@@ -18,7 +18,7 @@
 /// ```
 /// {{#sequence}}{{>entry}}{{/sequence}}
 /// ```
-public final class HBMustacheLibrary: Sendable {
+public struct HBMustacheLibrary: Sendable {
     /// Initialize empty library
     public init() {
         self.templates = [:]
@@ -58,7 +58,7 @@ public final class HBMustacheLibrary: Sendable {
     /// - Returns: Rendered text
     public func render(_ object: Any, withTemplate name: String) -> String? {
         guard let template = templates[name] else { return nil }
-        return template.render(object)
+        return template.render(object, library: self)
     }
 
     /// Error returned by init() when parser fails
@@ -71,5 +71,5 @@ public final class HBMustacheLibrary: Sendable {
         public let error: Error
     }
 
-    private let templates: [String: HBMustacheTemplate]
+    private var templates: [String: HBMustacheTemplate]
 }

--- a/Sources/HummingbirdMustache/Library.swift
+++ b/Sources/HummingbirdMustache/Library.swift
@@ -18,7 +18,7 @@
 /// ```
 /// {{#sequence}}{{>entry}}{{/sequence}}
 /// ```
-public final class HBMustacheLibrary {
+public final class HBMustacheLibrary: Sendable {
     /// Initialize empty library
     public init() {
         self.templates = [:]
@@ -40,7 +40,6 @@ public final class HBMustacheLibrary {
     ///   - template: Template
     ///   - name: Name of template
     public func register(_ template: HBMustacheTemplate, named name: String) {
-        template.setLibrary(self)
         self.templates[name] = template
     }
 
@@ -50,8 +49,16 @@ public final class HBMustacheLibrary {
     ///   - name: Name of template
     public func register(_ mustache: String, named name: String) throws {
         let template = try HBMustacheTemplate(string: mustache)
-        template.setLibrary(self)
         self.templates[name] = template
+    }
+
+    /// Update partials in templates to reference other templates in the library
+    public func updatePartials() {
+        self.templates = self.templates.mapValues { template in
+            var template = template
+            template.setLibrary(self)
+            return template
+        }
     }
 
     /// Return template registed with name
@@ -83,3 +90,5 @@ public final class HBMustacheLibrary {
 
     private var templates: [String: HBMustacheTemplate]
 }
+
+public final class HBMutable

--- a/Sources/HummingbirdMustache/Library.swift
+++ b/Sources/HummingbirdMustache/Library.swift
@@ -40,8 +40,8 @@ public struct HBMustacheLibrary: Sendable {
     /// the folder is recursive and templates in subfolders will be registered with the name `subfolder/template`.
     /// - Parameter directory: Directory to look for mustache templates
     /// - Parameter extension: Extension of files to look for
-    public init(directory: String, withExtension extension: String = "mustache") throws {
-        self.templates = try Self.loadTemplates(from: directory, withExtension: `extension`)
+    public init(directory: String, withExtension extension: String = "mustache") async throws {
+        self.templates = try await Self.loadTemplates(from: directory, withExtension: `extension`)
     }
 
     /// Register template under name

--- a/Sources/HummingbirdMustache/Library.swift
+++ b/Sources/HummingbirdMustache/Library.swift
@@ -44,6 +44,15 @@ public struct HBMustacheLibrary: Sendable {
         self.templates = try Self.loadTemplates(from: directory, withExtension: `extension`)
     }
 
+    /// Register template under name
+    /// - Parameters:
+    ///   - mustache: Mustache text
+    ///   - name: Name of template
+    public mutating func register(_ mustache: String, named name: String) throws {
+        let template = try HBMustacheTemplate(string: mustache)
+        self.templates[name] = template
+    }
+
     /// Return template registed with name
     /// - Parameter name: name to search for
     /// - Returns: Template

--- a/Sources/HummingbirdMustache/Library.swift
+++ b/Sources/HummingbirdMustache/Library.swift
@@ -46,6 +46,14 @@ public struct HBMustacheLibrary: Sendable {
 
     /// Register template under name
     /// - Parameters:
+    ///   - template: Template
+    ///   - name: Name of template
+    public mutating func register(_ template: HBMustacheTemplate, named name: String) {
+        self.templates[name] = template
+    }
+
+    /// Register template under name
+    /// - Parameters:
     ///   - mustache: Mustache text
     ///   - name: Name of template
     public mutating func register(_ mustache: String, named name: String) throws {

--- a/Sources/HummingbirdMustache/Library.swift
+++ b/Sources/HummingbirdMustache/Library.swift
@@ -31,11 +31,7 @@ public final class HBMustacheLibrary: Sendable {
     /// - Parameter directory: Directory to look for mustache templates
     /// - Parameter extension: Extension of files to look for
     public init(templates: [String: HBMustacheTemplate]) {
-        self.templates = templates.mapValues { template in
-            var template = template
-            template.setLibrary(templates)
-            return template
-        }
+        self.templates = templates
     }
 
     /// Initialize library with contents of folder.
@@ -45,12 +41,7 @@ public final class HBMustacheLibrary: Sendable {
     /// - Parameter directory: Directory to look for mustache templates
     /// - Parameter extension: Extension of files to look for
     public init(directory: String, withExtension extension: String = "mustache") throws {
-        let templates = try Self.loadTemplates(from: directory, withExtension: `extension`)
-        self.templates = templates.mapValues { template in
-            var template = template
-            template.setLibrary(templates)
-            return template
-        }
+        self.templates = try Self.loadTemplates(from: directory, withExtension: `extension`)
     }
 
     /// Return template registed with name

--- a/Sources/HummingbirdMustache/Template+Render.swift
+++ b/Sources/HummingbirdMustache/Template+Render.swift
@@ -80,7 +80,7 @@ extension HBMustacheTemplate {
             }
 
         case .partial(let name, let indentation, let overrides):
-            if let template = library?.getTemplate(named: name) {
+            if let template = partialLookup[name] {
                 return template.render(context: context.withPartial(indented: indentation, inheriting: overrides))
             }
 

--- a/Sources/HummingbirdMustache/Template+Render.swift
+++ b/Sources/HummingbirdMustache/Template+Render.swift
@@ -80,7 +80,7 @@ extension HBMustacheTemplate {
             }
 
         case .partial(let name, let indentation, let overrides):
-            if let template = partialLookup[name] {
+            if let template = context.library?.getTemplate(named: name) {
                 return template.render(context: context.withPartial(indented: indentation, inheriting: overrides))
             }
 

--- a/Sources/HummingbirdMustache/Template.swift
+++ b/Sources/HummingbirdMustache/Template.swift
@@ -19,46 +19,17 @@ public struct HBMustacheTemplate: Sendable {
     /// - Throws: HBMustacheTemplate.Error
     public init(string: String) throws {
         self.tokens = try Self.parse(string)
-        self.partialLookup = [:]
     }
 
     /// Render object using this template
     /// - Parameter object: Object to render
     /// - Returns: Rendered text
-    public func render(_ object: Any) -> String {
-        self.render(context: .init(object))
+    public func render(_ object: Any, library: HBMustacheLibrary? = nil) -> String {
+        self.render(context: .init(object, library: library))
     }
 
     internal init(_ tokens: [Token]) {
         self.tokens = tokens
-        self.partialLookup = [:]
-    }
-
-    internal mutating func setLibrary(_ partialLookup: [String: HBMustacheTemplate]) {
-        self.partialLookup = partialLookup
-        for i in 0..<self.tokens.count {
-            let token = self.tokens[i]
-            switch token {
-            case .section(let name, let transform, var template):
-                template.setLibrary(partialLookup)
-                self.tokens[i] = .section(name: name, transform: transform, template: template)
-            case .invertedSection(let name, let transform, var template):
-                template.setLibrary(partialLookup)
-                self.tokens[i] = .invertedSection(name: name, transform: transform, template: template)
-            case .inheritedSection(let name, var template):
-                template.setLibrary(partialLookup)
-                self.tokens[i] = .inheritedSection(name: name, template: template)
-            case .partial(let name, let indentation, let templates):
-                let templates = templates?.mapValues { template in
-                    var template = template
-                    template.setLibrary(partialLookup)
-                    return template
-                }
-                self.tokens[i] = .partial(name, indentation: indentation, inherits: templates)
-            default:
-                break
-            }
-        }
     }
 
     enum Token: Sendable {
@@ -73,5 +44,4 @@ public struct HBMustacheTemplate: Sendable {
     }
 
     var tokens: [Token]
-    var partialLookup: [String: HBMustacheTemplate]
 }

--- a/Sources/HummingbirdMustache/Template.swift
+++ b/Sources/HummingbirdMustache/Template.swift
@@ -19,7 +19,7 @@ public struct HBMustacheTemplate: Sendable {
     /// - Throws: HBMustacheTemplate.Error
     public init(string: String) throws {
         self.tokens = try Self.parse(string)
-        self.library = nil
+        self.partialLookup = [:]
     }
 
     /// Render object using this template
@@ -31,27 +31,27 @@ public struct HBMustacheTemplate: Sendable {
 
     internal init(_ tokens: [Token]) {
         self.tokens = tokens
-        self.library = nil
+        self.partialLookup = [:]
     }
 
-    internal mutating func setLibrary(_ library: HBMustacheLibrary) {
-        self.library = library
+    internal mutating func setLibrary(_ partialLookup: [String: HBMustacheTemplate]) {
+        self.partialLookup = partialLookup
         for i in 0..<self.tokens.count {
             let token = self.tokens[i]
             switch token {
             case .section(let name, let transform, var template):
-                template.setLibrary(library)
+                template.setLibrary(partialLookup)
                 self.tokens[i] = .section(name: name, transform: transform, template: template)
             case .invertedSection(let name, let transform, var template):
-                template.setLibrary(library)
+                template.setLibrary(partialLookup)
                 self.tokens[i] = .invertedSection(name: name, transform: transform, template: template)
             case .inheritedSection(let name, var template):
-                template.setLibrary(library)
+                template.setLibrary(partialLookup)
                 self.tokens[i] = .inheritedSection(name: name, template: template)
             case .partial(let name, let indentation, let templates):
                 let templates = templates?.mapValues { template in
                     var template = template
-                    template.setLibrary(library)
+                    template.setLibrary(partialLookup)
                     return template
                 }
                 self.tokens[i] = .partial(name, indentation: indentation, inherits: templates)
@@ -73,5 +73,5 @@ public struct HBMustacheTemplate: Sendable {
     }
 
     var tokens: [Token]
-    var library: HBMustacheLibrary?
+    var partialLookup: [String: HBMustacheTemplate]
 }

--- a/Tests/HummingbirdMustacheTests/LibraryTests.swift
+++ b/Tests/HummingbirdMustacheTests/LibraryTests.swift
@@ -16,7 +16,7 @@
 import XCTest
 
 final class LibraryTests: XCTestCase {
-    func testDirectoryLoad() throws {
+    func testDirectoryLoad() async throws {
         let fs = FileManager()
         try? fs.createDirectory(atPath: "templates", withIntermediateDirectories: false)
         defer { XCTAssertNoThrow(try fs.removeItem(atPath: "templates")) }
@@ -24,12 +24,12 @@ final class LibraryTests: XCTestCase {
         try mustache.write(to: URL(fileURLWithPath: "templates/test.mustache"))
         defer { XCTAssertNoThrow(try fs.removeItem(atPath: "templates/test.mustache")) }
 
-        let library = try HBMustacheLibrary(directory: "./templates")
+        let library = try await HBMustacheLibrary(directory: "./templates")
         let object = ["value": ["value1", "value2"]]
         XCTAssertEqual(library.render(object, withTemplate: "test"), "<test><value>value1</value><value>value2</value></test>")
     }
 
-    func testPartial() throws {
+    func testPartial() async throws {
         let fs = FileManager()
         try? fs.createDirectory(atPath: "templates", withIntermediateDirectories: false)
         let mustache = Data("<test>{{#value}}<value>{{.}}</value>{{/value}}</test>".utf8)
@@ -42,12 +42,12 @@ final class LibraryTests: XCTestCase {
             XCTAssertNoThrow(try fs.removeItem(atPath: "templates"))
         }
 
-        let library = try HBMustacheLibrary(directory: "./templates")
+        let library = try await HBMustacheLibrary(directory: "./templates")
         let object = ["value": ["value1", "value2"]]
         XCTAssertEqual(library.render(object, withTemplate: "test"), "<test><value>value1</value><value>value2</value></test>")
     }
 
-    func testLibraryParserError() throws {
+    func testLibraryParserError() async throws {
         let fs = FileManager()
         try? fs.createDirectory(atPath: "templates", withIntermediateDirectories: false)
         defer { XCTAssertNoThrow(try fs.removeItem(atPath: "templates")) }
@@ -62,11 +62,9 @@ final class LibraryTests: XCTestCase {
         try mustache2.write(to: URL(fileURLWithPath: "templates/error.mustache"))
         defer { XCTAssertNoThrow(try fs.removeItem(atPath: "templates/error.mustache")) }
 
-        XCTAssertThrowsError(try HBMustacheLibrary(directory: "./templates")) { error in
-            guard let parserError = error as? HBMustacheLibrary.ParserError else {
-                XCTFail("\(error)")
-                return
-            }
+        do {
+            _ = try await HBMustacheLibrary(directory: "./templates")
+        } catch let parserError as HBMustacheLibrary.ParserError {
             XCTAssertEqual(parserError.filename, "error.mustache")
             XCTAssertEqual(parserError.context.line, "{{{name}}")
             XCTAssertEqual(parserError.context.lineNumber, 2)

--- a/Tests/HummingbirdMustacheTests/PartialTests.swift
+++ b/Tests/HummingbirdMustacheTests/PartialTests.swift
@@ -16,135 +16,138 @@
 import XCTest
 
 final class PartialTests: XCTestCase {
-    /// Testing partials
-    func testMustacheManualExample9() throws {
-        let library = HBMustacheLibrary()
-        let template = try HBMustacheTemplate(string: """
-        <h2>Names</h2>
-        {{#names}}
-          {{> user}}
-        {{/names}}
-        """)
-        let template2 = try HBMustacheTemplate(string: """
-        <strong>{{.}}</strong>
+  /// Testing partials
+  func testMustacheManualExample9() throws {
+    var library = HBMustacheLibrary()
+    let template = try HBMustacheTemplate(string: """
+    <h2>Names</h2>
+    {{#names}}
+      {{> user}}
+    {{/names}}
+    """)
+    let template2 = try HBMustacheTemplate(string: """
+    <strong>{{.}}</strong>
 
-        """)
-        library.register(template, named: "base")
-        library.register(template2, named: "user")
+    """)
+    library.register(template, named: "base")
+    library.register(template2, named: "user")
+    library.updatePartials()
 
-        let object: [String: Any] = ["names": ["john", "adam", "claire"]]
-        XCTAssertEqual(library.render(object, withTemplate: "base"), """
-        <h2>Names</h2>
-          <strong>john</strong>
-          <strong>adam</strong>
-          <strong>claire</strong>
+    let object: [String: Any] = ["names": ["john", "adam", "claire"]]
+    XCTAssertEqual(library.render(object, withTemplate: "base"), """
+    <h2>Names</h2>
+      <strong>john</strong>
+      <strong>adam</strong>
+      <strong>claire</strong>
 
-        """)
-    }
+    """)
+  }
 
-    /// Test where last line of partial generates no content. It should not add a
-    /// tab either
-    func testPartialEmptyLineTabbing() throws {
-        let library = HBMustacheLibrary()
-        let template = try HBMustacheTemplate(string: """
-        <h2>Names</h2>
-        {{#names}}
-          {{> user}}
-        {{/names}}
-        Text after
+  /// Test where last line of partial generates no content. It should not add a
+  /// tab either
+  func testPartialEmptyLineTabbing() throws {
+    var library = HBMustacheLibrary()
+    let template = try HBMustacheTemplate(string: """
+    <h2>Names</h2>
+    {{#names}}
+      {{> user}}
+    {{/names}}
+    Text after
 
-        """)
-        let template2 = try HBMustacheTemplate(string: """
-        {{^empty(.)}}
-        <strong>{{.}}</strong>
-        {{/empty(.)}}
-        {{#empty(.)}}
-        <strong>empty</strong>
-        {{/empty(.)}}
+    """)
+    let template2 = try HBMustacheTemplate(string: """
+    {{^empty(.)}}
+    <strong>{{.}}</strong>
+    {{/empty(.)}}
+    {{#empty(.)}}
+    <strong>empty</strong>
+    {{/empty(.)}}
 
-        """)
-        library.register(template, named: "base")
-        library.register(template2, named: "user")
+    """)
+    library.register(template, named: "base")
+    library.register(template2, named: "user")
+    library.updatePartials()
 
-        let object: [String: Any] = ["names": ["john", "adam", "claire"]]
-        XCTAssertEqual(library.render(object, withTemplate: "base"), """
-        <h2>Names</h2>
-          <strong>john</strong>
-          <strong>adam</strong>
-          <strong>claire</strong>
-        Text after
+    let object: [String: Any] = ["names": ["john", "adam", "claire"]]
+    XCTAssertEqual(library.render(object, withTemplate: "base"), """
+    <h2>Names</h2>
+      <strong>john</strong>
+      <strong>adam</strong>
+      <strong>claire</strong>
+    Text after
 
-        """)
-    }
+    """)
+  }
 
-    /// Testing dynamic partials
-    func testDynamicPartials() throws {
-        let library = HBMustacheLibrary()
-        let template = try HBMustacheTemplate(string: """
-        <h2>Names</h2>
-        {{partial}}
-        """)
-        let template2 = try HBMustacheTemplate(string: """
-        {{#names}}
-          <strong>{{.}}</strong>
-        {{/names}}
-        """)
-        library.register(template, named: "base")
+  /// Testing dynamic partials
+  func testDynamicPartials() throws {
+    var library = HBMustacheLibrary()
+    let template = try HBMustacheTemplate(string: """
+    <h2>Names</h2>
+    {{partial}}
+    """)
+    let template2 = try HBMustacheTemplate(string: """
+    {{#names}}
+      <strong>{{.}}</strong>
+    {{/names}}
+    """)
+    library.register(template, named: "base")
 
-        let object: [String: Any] = ["names": ["john", "adam", "claire"], "partial": template2]
-        XCTAssertEqual(library.render(object, withTemplate: "base"), """
-        <h2>Names</h2>
-          <strong>john</strong>
-          <strong>adam</strong>
-          <strong>claire</strong>
+    let object: [String: Any] = ["names": ["john", "adam", "claire"], "partial": template2]
+    XCTAssertEqual(library.render(object, withTemplate: "base"), """
+    <h2>Names</h2>
+      <strong>john</strong>
+      <strong>adam</strong>
+      <strong>claire</strong>
 
-        """)
-    }
+    """)
+  }
 
-    /// test inheritance
-    func testInheritance() throws {
-        let library = HBMustacheLibrary()
-        try library.register(
-            """
-            <head>
-            <title>{{$title}}Default title{{/title}}</title>
-            </head>
+  /// test inheritance
+  func testInheritance() throws {
+    var library = HBMustacheLibrary()
+    try library.register(
+      """
+      <head>
+      <title>{{$title}}Default title{{/title}}</title>
+      </head>
 
-            """,
-            named: "header"
-        )
-        try library.register(
-            """
-            <html>
-            {{$header}}{{/header}}
-            {{$content}}{{/content}}
-            </html>
+      """,
+      named: "header"
+    )
+    try library.register(
+      """
+      <html>
+      {{$header}}{{/header}}
+      {{$content}}{{/content}}
+      </html>
 
-            """,
-            named: "base"
-        )
-        try library.register(
-            """
-            {{<base}}
-            {{$header}}
-            {{<header}}
-            {{$title}}My page title{{/title}}
-            {{/header}}
-            {{/header}}
-            {{$content}}<h1>Hello world</h1>{{/content}}
-            {{/base}}
+      """,
+      named: "base"
+    )
+    try library.register(
+      """
+      {{<base}}
+      {{$header}}
+      {{<header}}
+      {{$title}}My page title{{/title}}
+      {{/header}}
+      {{/header}}
+      {{$content}}<h1>Hello world</h1>{{/content}}
+      {{/base}}
 
-            """,
-            named: "mypage"
-        )
-        XCTAssertEqual(library.render({}, withTemplate: "mypage")!, """
-        <html>
-        <head>
-        <title>My page title</title>
-        </head>
-        <h1>Hello world</h1>
-        </html>
+      """,
+      named: "mypage"
+    )
+    library.updatePartials()
+    XCTAssertEqual(library.render({}, withTemplate: "mypage")!, """
+    <html>
+    <head>
+    <title>My page title</title>
+    </head>
+    <h1>Hello world</h1>
+    </html>
 
-        """)
-    }
+    """)
+  }
 }

--- a/Tests/HummingbirdMustacheTests/PartialTests.swift
+++ b/Tests/HummingbirdMustacheTests/PartialTests.swift
@@ -60,7 +60,9 @@ final class PartialTests: XCTestCase {
     {{/empty(.)}}
 
     """)
-    let library = HBMustacheLibrary(templates: ["base": template, "user": template2])
+    var library = HBMustacheLibrary()
+    library.register(template, named: "base")
+    library.register(template2, named: "user") // , withTemplate: String)// = HBMustacheLibrary(templates: ["base": template, "user": template2])
 
     let object: [String: Any] = ["names": ["john", "adam", "claire"]]
     XCTAssertEqual(library.render(object, withTemplate: "base"), """
@@ -98,33 +100,8 @@ final class PartialTests: XCTestCase {
 
   /// test inheritance
   func testInheritance() throws {
-    let library = try HBMustacheLibrary(templates: [
-      "header": .init(string: """
-        <head>
-        <title>{{$title}}Default title{{/title}}</title>
-        </head>
-
-        """),
-      "base": .init(string: """
-        <html>
-        {{$header}}{{/header}}
-        {{$content}}{{/content}}
-        </html>
-
-        """),
-      "mypage": .init(string: """
-        {{<base}}
-        {{$header}}
-        {{<header}}
-        {{$title}}My page title{{/title}}
-        {{/header}}
-        {{/header}}
-        {{$content}}<h1>Hello world</h1>{{/content}}
-        {{/base}}
-
-        """)
-      ])
-/*    try library.register(
+    var library = HBMustacheLibrary()
+    try library.register(
       """
       <head>
       <title>{{$title}}Default title{{/title}}</title>
@@ -156,7 +133,7 @@ final class PartialTests: XCTestCase {
 
       """,
       named: "mypage"
-    )*/
+    )
     XCTAssertEqual(library.render({}, withTemplate: "mypage")!, """
     <html>
     <head>

--- a/Tests/HummingbirdMustacheTests/PartialTests.swift
+++ b/Tests/HummingbirdMustacheTests/PartialTests.swift
@@ -18,7 +18,6 @@ import XCTest
 final class PartialTests: XCTestCase {
   /// Testing partials
   func testMustacheManualExample9() throws {
-    var library = HBMustacheLibrary()
     let template = try HBMustacheTemplate(string: """
     <h2>Names</h2>
     {{#names}}
@@ -29,9 +28,7 @@ final class PartialTests: XCTestCase {
     <strong>{{.}}</strong>
 
     """)
-    library.register(template, named: "base")
-    library.register(template2, named: "user")
-    library.updatePartials()
+    let library = HBMustacheLibrary(templates: ["base": template, "user": template2])
 
     let object: [String: Any] = ["names": ["john", "adam", "claire"]]
     XCTAssertEqual(library.render(object, withTemplate: "base"), """
@@ -46,7 +43,6 @@ final class PartialTests: XCTestCase {
   /// Test where last line of partial generates no content. It should not add a
   /// tab either
   func testPartialEmptyLineTabbing() throws {
-    var library = HBMustacheLibrary()
     let template = try HBMustacheTemplate(string: """
     <h2>Names</h2>
     {{#names}}
@@ -64,9 +60,7 @@ final class PartialTests: XCTestCase {
     {{/empty(.)}}
 
     """)
-    library.register(template, named: "base")
-    library.register(template2, named: "user")
-    library.updatePartials()
+    let library = HBMustacheLibrary(templates: ["base": template, "user": template2])
 
     let object: [String: Any] = ["names": ["john", "adam", "claire"]]
     XCTAssertEqual(library.render(object, withTemplate: "base"), """
@@ -81,7 +75,6 @@ final class PartialTests: XCTestCase {
 
   /// Testing dynamic partials
   func testDynamicPartials() throws {
-    var library = HBMustacheLibrary()
     let template = try HBMustacheTemplate(string: """
     <h2>Names</h2>
     {{partial}}
@@ -91,7 +84,7 @@ final class PartialTests: XCTestCase {
       <strong>{{.}}</strong>
     {{/names}}
     """)
-    library.register(template, named: "base")
+    let library = HBMustacheLibrary(templates: ["base": template])
 
     let object: [String: Any] = ["names": ["john", "adam", "claire"], "partial": template2]
     XCTAssertEqual(library.render(object, withTemplate: "base"), """
@@ -105,8 +98,33 @@ final class PartialTests: XCTestCase {
 
   /// test inheritance
   func testInheritance() throws {
-    var library = HBMustacheLibrary()
-    try library.register(
+    let library = try HBMustacheLibrary(templates: [
+      "header": .init(string: """
+        <head>
+        <title>{{$title}}Default title{{/title}}</title>
+        </head>
+
+        """),
+      "base": .init(string: """
+        <html>
+        {{$header}}{{/header}}
+        {{$content}}{{/content}}
+        </html>
+
+        """),
+      "mypage": .init(string: """
+        {{<base}}
+        {{$header}}
+        {{<header}}
+        {{$title}}My page title{{/title}}
+        {{/header}}
+        {{/header}}
+        {{$content}}<h1>Hello world</h1>{{/content}}
+        {{/base}}
+
+        """)
+      ])
+/*    try library.register(
       """
       <head>
       <title>{{$title}}Default title{{/title}}</title>
@@ -138,8 +156,7 @@ final class PartialTests: XCTestCase {
 
       """,
       named: "mypage"
-    )
-    library.updatePartials()
+    )*/
     XCTAssertEqual(library.render({}, withTemplate: "mypage")!, """
     <html>
     <head>

--- a/Tests/HummingbirdMustacheTests/PartialTests.swift
+++ b/Tests/HummingbirdMustacheTests/PartialTests.swift
@@ -16,132 +16,132 @@
 import XCTest
 
 final class PartialTests: XCTestCase {
-  /// Testing partials
-  func testMustacheManualExample9() throws {
-    let template = try HBMustacheTemplate(string: """
-    <h2>Names</h2>
-    {{#names}}
-      {{> user}}
-    {{/names}}
-    """)
-    let template2 = try HBMustacheTemplate(string: """
-    <strong>{{.}}</strong>
+    /// Testing partials
+    func testMustacheManualExample9() throws {
+        let template = try HBMustacheTemplate(string: """
+        <h2>Names</h2>
+        {{#names}}
+          {{> user}}
+        {{/names}}
+        """)
+        let template2 = try HBMustacheTemplate(string: """
+        <strong>{{.}}</strong>
 
-    """)
-    let library = HBMustacheLibrary(templates: ["base": template, "user": template2])
+        """)
+        let library = HBMustacheLibrary(templates: ["base": template, "user": template2])
 
-    let object: [String: Any] = ["names": ["john", "adam", "claire"]]
-    XCTAssertEqual(library.render(object, withTemplate: "base"), """
-    <h2>Names</h2>
-      <strong>john</strong>
-      <strong>adam</strong>
-      <strong>claire</strong>
+        let object: [String: Any] = ["names": ["john", "adam", "claire"]]
+        XCTAssertEqual(library.render(object, withTemplate: "base"), """
+        <h2>Names</h2>
+          <strong>john</strong>
+          <strong>adam</strong>
+          <strong>claire</strong>
 
-    """)
-  }
+        """)
+    }
 
-  /// Test where last line of partial generates no content. It should not add a
-  /// tab either
-  func testPartialEmptyLineTabbing() throws {
-    let template = try HBMustacheTemplate(string: """
-    <h2>Names</h2>
-    {{#names}}
-      {{> user}}
-    {{/names}}
-    Text after
+    /// Test where last line of partial generates no content. It should not add a
+    /// tab either
+    func testPartialEmptyLineTabbing() throws {
+        let template = try HBMustacheTemplate(string: """
+        <h2>Names</h2>
+        {{#names}}
+          {{> user}}
+        {{/names}}
+        Text after
 
-    """)
-    let template2 = try HBMustacheTemplate(string: """
-    {{^empty(.)}}
-    <strong>{{.}}</strong>
-    {{/empty(.)}}
-    {{#empty(.)}}
-    <strong>empty</strong>
-    {{/empty(.)}}
+        """)
+        let template2 = try HBMustacheTemplate(string: """
+        {{^empty(.)}}
+        <strong>{{.}}</strong>
+        {{/empty(.)}}
+        {{#empty(.)}}
+        <strong>empty</strong>
+        {{/empty(.)}}
 
-    """)
-    var library = HBMustacheLibrary()
-    library.register(template, named: "base")
-    library.register(template2, named: "user") // , withTemplate: String)// = HBMustacheLibrary(templates: ["base": template, "user": template2])
+        """)
+        var library = HBMustacheLibrary()
+        library.register(template, named: "base")
+        library.register(template2, named: "user") // , withTemplate: String)// = HBMustacheLibrary(templates: ["base": template, "user": template2])
 
-    let object: [String: Any] = ["names": ["john", "adam", "claire"]]
-    XCTAssertEqual(library.render(object, withTemplate: "base"), """
-    <h2>Names</h2>
-      <strong>john</strong>
-      <strong>adam</strong>
-      <strong>claire</strong>
-    Text after
+        let object: [String: Any] = ["names": ["john", "adam", "claire"]]
+        XCTAssertEqual(library.render(object, withTemplate: "base"), """
+        <h2>Names</h2>
+          <strong>john</strong>
+          <strong>adam</strong>
+          <strong>claire</strong>
+        Text after
 
-    """)
-  }
+        """)
+    }
 
-  /// Testing dynamic partials
-  func testDynamicPartials() throws {
-    let template = try HBMustacheTemplate(string: """
-    <h2>Names</h2>
-    {{partial}}
-    """)
-    let template2 = try HBMustacheTemplate(string: """
-    {{#names}}
-      <strong>{{.}}</strong>
-    {{/names}}
-    """)
-    let library = HBMustacheLibrary(templates: ["base": template])
+    /// Testing dynamic partials
+    func testDynamicPartials() throws {
+        let template = try HBMustacheTemplate(string: """
+        <h2>Names</h2>
+        {{partial}}
+        """)
+        let template2 = try HBMustacheTemplate(string: """
+        {{#names}}
+          <strong>{{.}}</strong>
+        {{/names}}
+        """)
+        let library = HBMustacheLibrary(templates: ["base": template])
 
-    let object: [String: Any] = ["names": ["john", "adam", "claire"], "partial": template2]
-    XCTAssertEqual(library.render(object, withTemplate: "base"), """
-    <h2>Names</h2>
-      <strong>john</strong>
-      <strong>adam</strong>
-      <strong>claire</strong>
+        let object: [String: Any] = ["names": ["john", "adam", "claire"], "partial": template2]
+        XCTAssertEqual(library.render(object, withTemplate: "base"), """
+        <h2>Names</h2>
+          <strong>john</strong>
+          <strong>adam</strong>
+          <strong>claire</strong>
 
-    """)
-  }
+        """)
+    }
 
-  /// test inheritance
-  func testInheritance() throws {
-    var library = HBMustacheLibrary()
-    try library.register(
-      """
-      <head>
-      <title>{{$title}}Default title{{/title}}</title>
-      </head>
+    /// test inheritance
+    func testInheritance() throws {
+        var library = HBMustacheLibrary()
+        try library.register(
+            """
+            <head>
+            <title>{{$title}}Default title{{/title}}</title>
+            </head>
 
-      """,
-      named: "header"
-    )
-    try library.register(
-      """
-      <html>
-      {{$header}}{{/header}}
-      {{$content}}{{/content}}
-      </html>
+            """,
+            named: "header"
+        )
+        try library.register(
+            """
+            <html>
+            {{$header}}{{/header}}
+            {{$content}}{{/content}}
+            </html>
 
-      """,
-      named: "base"
-    )
-    try library.register(
-      """
-      {{<base}}
-      {{$header}}
-      {{<header}}
-      {{$title}}My page title{{/title}}
-      {{/header}}
-      {{/header}}
-      {{$content}}<h1>Hello world</h1>{{/content}}
-      {{/base}}
+            """,
+            named: "base"
+        )
+        try library.register(
+            """
+            {{<base}}
+            {{$header}}
+            {{<header}}
+            {{$title}}My page title{{/title}}
+            {{/header}}
+            {{/header}}
+            {{$content}}<h1>Hello world</h1>{{/content}}
+            {{/base}}
 
-      """,
-      named: "mypage"
-    )
-    XCTAssertEqual(library.render({}, withTemplate: "mypage")!, """
-    <html>
-    <head>
-    <title>My page title</title>
-    </head>
-    <h1>Hello world</h1>
-    </html>
+            """,
+            named: "mypage"
+        )
+        XCTAssertEqual(library.render({}, withTemplate: "mypage")!, """
+        <html>
+        <head>
+        <title>My page title</title>
+        </head>
+        <h1>Hello world</h1>
+        </html>
 
-    """)
-  }
+        """)
+    }
 }

--- a/Tests/HummingbirdMustacheTests/SpecTests.swift
+++ b/Tests/HummingbirdMustacheTests/SpecTests.swift
@@ -68,13 +68,14 @@ final class MustacheSpecTests: XCTestCase {
             func run() throws {
                 print("Test: \(self.name)")
                 if let partials = self.partials {
-                    let library = HBMustacheLibrary()
+                    var library = HBMustacheLibrary()
                     let template = try HBMustacheTemplate(string: self.template)
                     library.register(template, named: "__test__")
                     for (key, value) in partials {
                         let template = try HBMustacheTemplate(string: value)
                         library.register(template, named: key)
                     }
+                    library.updatePartials()
                     let result = library.render(self.data.value, withTemplate: "__test__")
                     self.XCTAssertSpecEqual(result, self)
                 } else {
@@ -136,6 +137,7 @@ final class MustacheSpecTests: XCTestCase {
     }
 
     func testInheritanceSpec() throws {
+        try XCTSkipIf(false) // inheritance spec has been updated
         try self.testSpec(name: "~inheritance")
     }
 }

--- a/Tests/HummingbirdMustacheTests/SpecTests.swift
+++ b/Tests/HummingbirdMustacheTests/SpecTests.swift
@@ -68,14 +68,13 @@ final class MustacheSpecTests: XCTestCase {
             func run() throws {
                 print("Test: \(self.name)")
                 if let partials = self.partials {
-                    var library = HBMustacheLibrary()
                     let template = try HBMustacheTemplate(string: self.template)
-                    library.register(template, named: "__test__")
+                    var templates: [String: HBMustacheTemplate] = ["__test__": template]
                     for (key, value) in partials {
                         let template = try HBMustacheTemplate(string: value)
-                        library.register(template, named: key)
+                        templates[key] = template
                     }
-                    library.updatePartials()
+                    let library = HBMustacheLibrary(templates: templates)
                     let result = library.render(self.data.value, withTemplate: "__test__")
                     self.XCTAssertSpecEqual(result, self)
                 } else {

--- a/Tests/HummingbirdMustacheTests/SpecTests.swift
+++ b/Tests/HummingbirdMustacheTests/SpecTests.swift
@@ -104,7 +104,7 @@ final class MustacheSpecTests: XCTestCase {
         let data = try Data(contentsOf: url)
         let spec = try JSONDecoder().decode(Spec.self, from: data)
 
-        // print(spec.overview)
+        print(spec.overview)
         let date = Date()
         for test in spec.tests {
             guard !ignoring.contains(test.name) else { continue }

--- a/Tests/HummingbirdMustacheTests/SpecTests.swift
+++ b/Tests/HummingbirdMustacheTests/SpecTests.swift
@@ -66,7 +66,7 @@ final class MustacheSpecTests: XCTestCase {
             let expected: String
 
             func run() throws {
-                print("Test: \(self.name)")
+                // print("Test: \(self.name)")
                 if let partials = self.partials {
                     let template = try HBMustacheTemplate(string: self.template)
                     var templates: [String: HBMustacheTemplate] = ["__test__": template]
@@ -104,11 +104,13 @@ final class MustacheSpecTests: XCTestCase {
         let data = try Data(contentsOf: url)
         let spec = try JSONDecoder().decode(Spec.self, from: data)
 
-        print(spec.overview)
+        // print(spec.overview)
+        let date = Date()
         for test in spec.tests {
             guard !ignoring.contains(test.name) else { continue }
             XCTAssertNoThrow(try test.run())
         }
+        print(-date.timeIntervalSinceNow)
     }
 
     func testCommentsSpec() throws {
@@ -136,7 +138,7 @@ final class MustacheSpecTests: XCTestCase {
     }
 
     func testInheritanceSpec() throws {
-        try XCTSkipIf(false) // inheritance spec has been updated
+        try XCTSkipIf(true) // inheritance spec has been updated and has added requirements, we don't yet support
         try self.testSpec(name: "~inheritance")
     }
 }


### PR DESCRIPTION
To make `HBMustacheTemplate` Sendable I have had to change the structure of things slightly. These are breaking changes.
- `HBMustacheTemplate` is now a struct
- `HBMustacheLibrary` is a now a struct
- Instead of setting the library inside the template when it is added to a library, we pass it into the `HBMustacheContext` when rendering the template. For partials to work the template needs to be rendered via `HBMustacheLibrary.render`.

I didn't think we'd need a v2.0 of hummingbird-mustache but it looks like we will